### PR TITLE
Add HostPool connection metadata support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Exclude:
     - lib/remotus/ssh_connection.rb
+
+Metrics/ParameterLists:
+  Max: 6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    remotus (0.1.0)
+    remotus (0.2.0)
       connection_pool (~> 2.2)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)
@@ -88,6 +88,7 @@ GEM
     yard (0.9.26)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -100,4 +101,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.9
+   2.2.14

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ connection = Remotus.connect("remotehost.local")
 # Initialize a new connection pool to remotehost.local with a defined protocol and port
 connection = Remotus.connect("remotehost.local", proto: :ssh, port: 2222)
 
+# Initialize a new connection pool to remotehost.local with a defined protocol and port and arbitrary metadata
+connection = Remotus.connect("remotehost.local", proto: :ssh, port: 2222, company: "Test Corp", location: "Oslo")
+
 # Create a credential for the new connection pool
 connection.credential = Remotus::Auth::Credential.new("username", "password")
 

--- a/lib/remotus.rb
+++ b/lib/remotus.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "remotus/core_ext/string"
 require "remotus/version"
 require "remotus/logger"
 require "remotus/pool"
@@ -139,4 +140,7 @@ module Remotus
 
   # Failed to find credential password when executing sudo command
   class MissingSudoPassword < Error; end
+
+  # Raised when an invalid metadata key is provided to a Remotus HostPool
+  class InvalidMetadataKey < Error; end
 end

--- a/lib/remotus/core_ext/string.rb
+++ b/lib/remotus/core_ext/string.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Remotus
+  # Core Ruby extensions
+  module CoreExt
+    # String extension module
+    module String
+      unless method_defined?(:to_method_name)
+        #
+        # Converts a string into a safe method name that can be used for instance variables
+        #
+        # @return [Symbol] Method name
+        #
+        def to_method_name
+          gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+            .gsub(/([a-z])([A-Z])/, '\1_\2')
+            .tr(" ", "_")
+            .gsub(/(?:[^_a-zA-Z0-9]|^\d+)/, "")
+            .downcase
+            .to_sym
+        end
+      end
+    end
+  end
+end
+
+String.include(Remotus::CoreExt::String)

--- a/lib/remotus/pool.rb
+++ b/lib/remotus/pool.rb
@@ -145,6 +145,9 @@ module Remotus
 
         options.each do |k, v|
           Remotus.logger.debug { "Checking if option #{k} => #{v} has changed" }
+
+          next unless pool[host].respond_to?(k.to_sym)
+
           host_value = pool[host].send(k.to_sym)
 
           if v != host_value

--- a/lib/remotus/version.rb
+++ b/lib/remotus/version.rb
@@ -2,5 +2,5 @@
 
 module Remotus
   # Remotus gem version
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/remotus/core_ext/string_spec.rb
+++ b/spec/remotus/core_ext/string_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Remotus::CoreExt::String do
+  let(:data) do
+    {
+      "TestThisThing" => :test_this_thing,
+      "123Invalid_start" => :invalid_start,
+      "   many    spaces" => :___many____spaces,
+      "OSThing" => :os_thing,
+      "!@#$%^&*&()-=invalid_starting_characters" => :invalid_starting_characters,
+      "Invalid!@#$%^&*()-=_Interior_chars" => :invalid_interior_chars
+    }
+  end
+
+  describe "#to_method_name" do
+    it "converts the string to a safe method name that can be used for instance variables" do
+      data.each do |str, out|
+        expect(str.to_method_name).to eq(out)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Add support for arbitrary metadata to be attached to each
Remotus::HostPool upon initialization. This is useful when defining
additional authentication stores that may need more information than the
hostname to gather appropriate credentials.