### PR TITLE
Ensure missing credentials are populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.2.2] - 2021-03-23
+* Ensure both user and password are populated before using a cached credential
+
 ## [0.2.1] - 2021-03-15
 * Fix connection pooling metadata sharing
 * Fix caching of pooled metadata

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    remotus (0.2.1)
+    remotus (0.2.2)
       connection_pool (~> 2.2)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)

--- a/lib/remotus/version.rb
+++ b/lib/remotus/version.rb
@@ -2,5 +2,5 @@
 
 module Remotus
   # Remotus gem version
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/remotus/auth_spec.rb
+++ b/spec/remotus/auth_spec.rb
@@ -12,6 +12,33 @@ RSpec.describe Remotus::Auth do
   end
 
   describe "#credential" do
+    context "when the cache contains a host credential without a username or password" do
+      it "retrieves and caches a new credential" do
+        described_class.cache[host] = described_class::Credential.new(nil, nil)
+        described_class.stores = [hash_store]
+        hash_store.add(connection, cred)
+        expect(described_class.credential(connection)).to eq(cred)
+      end
+    end
+
+    context "when the cache contains a host credential without a username" do
+      it "retrieves and caches a new credential" do
+        described_class.cache[host] = described_class::Credential.new(nil, "password")
+        described_class.stores = [hash_store]
+        hash_store.add(connection, cred)
+        expect(described_class.credential(connection)).to eq(cred)
+      end
+    end
+
+    context "when the cache contains a host credential without a password" do
+      it "retrieves and caches a new credential" do
+        described_class.cache[host] = described_class::Credential.new("diff_user", nil)
+        described_class.stores = [hash_store]
+        hash_store.add(connection, cred)
+        expect(described_class.credential(connection)).to eq(cred)
+      end
+    end
+
     context "when the cache contains the host credential" do
       it "returns the credential" do
         described_class.cache[host] = cred


### PR DESCRIPTION
This change ensures that cached credentials are only used if they have a
defined user and password. This is necessary in situations where the
cached credential may have been incorrectly populated prior to usage in
an SSH or WinRM connection.