### PR TITLE
Resolve rexml vulnerability CVE-2021-28965

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Style/StringLiterals:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.2.3] - 2021-05-01
+* Resolve rexml vulnerability CVE-2021-28965
+
 ## [0.2.2] - 2021-03-23
 * Ensure both user and password are populated before using a cached credential
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    remotus (0.2.2)
+    remotus (0.2.3)
       connection_pool (~> 2.2)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)
@@ -13,7 +13,7 @@ GEM
   specs:
     ast (2.4.2)
     builder (3.2.4)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     ffi (1.15.0)
@@ -32,12 +32,12 @@ GEM
     net-ssh (6.1.0)
     nori (2.6.0)
     parallel (1.20.1)
-    parser (3.0.0.0)
+    parser (3.0.1.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.1.1)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -51,7 +51,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.11.0)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -64,7 +64,7 @@ GEM
       parser (>= 2.7.1.5)
     rubocop-rake (0.5.1)
       rubocop
-    rubocop-rspec (2.2.0)
+    rubocop-rspec (2.3.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)

--- a/lib/remotus/version.rb
+++ b/lib/remotus/version.rb
@@ -2,5 +2,5 @@
 
 module Remotus
   # Remotus gem version
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/remotus.gemspec
+++ b/remotus.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Ruby gem for connecting to remote systems seamlessly via WinRM or SSH."
   spec.homepage      = "https://github.com/wheatevo/remotus"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/wheatevo/remotus"


### PR DESCRIPTION
This change resolves rexml vulnerability CVE-2021-28965 by updating gem
dependencies. Updates have also been made to require ruby 2.5+.