### PR TITLE
Winrm elevated privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.4.0] - 2022-06-02
+* Added winrm-elevated gem to solve wirnrm AuthenticationError
+
 ## [0.3.0] - 2022-02-18
 * Add retries to SSH SCP transactions
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       net-scp (~> 3.0)
       net-ssh (~> 6.1)
       winrm (~> 2.3)
-      winrm-elevated (~> 1.2.3)
+      winrm-elevated (~> 1.2)
       winrm-fs (~> 1.3)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 PATH
   remote: .
   specs:
-    remotus (0.3.0)
+    remotus (0.4.0)
       connection_pool (~> 2.2)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)
       winrm (~> 2.3)
+      winrm-elevated (~> 1.2.3)
       winrm-fs (~> 1.3)
 
 GEM
@@ -19,11 +20,12 @@ GEM
     ffi (1.15.5)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     httpclient (2.8.3)
     little-plugger (1.1.4)
-    logging (2.3.0)
+    logging (2.3.1)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
     multi_json (1.15.0)
@@ -80,6 +82,10 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.3)
+    winrm-elevated (1.2.3)
+      erubi (~> 1.8)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
     winrm-fs (1.3.5)
       erubi (~> 1.8)
       logging (>= 1.6.1, < 3.0)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ result.exit_code
 # Run a command on the remote host with sudo (Linux only, requires password to be specified)
 result = connection.run("ls /root", sudo: true)
 
+# Run a command on the remote host with elevated shell privilege
+result = connection.run("ipconfg", options: {shell: :elevated})
+
 # Run a script on the remote host
 connection.run_script("/local/script.sh", "/remote/path/script.sh")
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ result.exit_code
 result = connection.run("ls /root", sudo: true)
 
 # Run a command on the remote host with elevated shell privilege
-result = connection.run("ipconfg", options: {shell: :elevated})
+result = connection.run("ipconfg", shell: :elevated)
 
 # Run a script on the remote host
 connection.run_script("/local/script.sh", "/remote/path/script.sh")

--- a/lib/remotus/core_ext/elevated.rb
+++ b/lib/remotus/core_ext/elevated.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "winrm-elevated"
+
+module Remotus
+  # Core Ruby extensions
+  module CoreExt
+    # Elevated extension module
+    module Elevated
+      unless method_defined?(:connection_opts)
+        #
+        #  Returns a hash into a safe method name that can be used for instance variables
+        #
+        # @return [Hash] Method name
+        #
+        def connection_opts
+          @shell.connection_opts
+        end
+      end
+    end
+  end
+end
+
+WinRM::Shells::Elevated.include(Remotus::CoreExt::Elevated)

--- a/lib/remotus/version.rb
+++ b/lib/remotus/version.rb
@@ -2,5 +2,5 @@
 
 module Remotus
   # Remotus gem version
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/lib/remotus/winrm_connection.rb
+++ b/lib/remotus/winrm_connection.rb
@@ -5,6 +5,7 @@ require "remotus"
 require "remotus/result"
 require "remotus/auth"
 require "winrm"
+require "winrm-elevated"
 require "winrm-fs"
 
 module Remotus
@@ -102,7 +103,7 @@ module Remotus
     #
     def run(command, *args, **options)
       command = "#{command}#{args.empty? ? "" : " "}#{args.join(" ")}"
-      run_result = connection(options[:type]).run(command)
+      run_result = options[:type].nil? ? connection.run(command) : connection(options[:type]).run(command)
       Remotus::Result.new(command, run_result.stdout, run_result.stderr, run_result.output, run_result.exitcode)
     rescue WinRM::WinRMAuthorizationError => e
       raise Remotus::AuthenticationError, e.to_s

--- a/lib/remotus/winrm_connection.rb
+++ b/lib/remotus/winrm_connection.rb
@@ -71,15 +71,15 @@ module Remotus
     #
     # Retrieves/creates the WinRM shell connection for the host
     #
-    # @param [symbol] type command type
+    # @param [symbol] shell connection shell type, defaults to :powershell
     # If the connection already exists, the existing connection will be retrieved
     #
-    # @return [WinRM::Shells::type] remote connection
+    # @return [WinRM::Shells::Powershell, WinRM::Shells::Elevated] remote connection
     #
-    def connection(type = :powershell)
+    def connection(shell = :powershell)
       return @connection unless restart_connection?
 
-      @connection = base_connection(reload: true).shell(type)
+      @connection = base_connection(reload: true).shell(shell)
     end
 
     #
@@ -97,13 +97,13 @@ module Remotus
     # @param [String] command command to run
     # @param [Array] args command arguments
     # @param [Hash] options command options
-    # @param [Hash] options type :symbol
+    # @param options [Symbol] :shell shell type to use for the connection
     #
     # @return [Remotus::Result] result describing the stdout, stderr, and exit status of the command
     #
     def run(command, *args, **options)
       command = "#{command}#{args.empty? ? "" : " "}#{args.join(" ")}"
-      run_result = options[:type].nil? ? connection.run(command) : connection(options[:type]).run(command)
+      run_result = options[:shell].nil? ? connection.run(command) : connection(options[:shell]).run(command)
       Remotus::Result.new(command, run_result.stdout, run_result.stderr, run_result.output, run_result.exitcode)
     rescue WinRM::WinRMAuthorizationError => e
       raise Remotus::AuthenticationError, e.to_s

--- a/lib/remotus/winrm_connection.rb
+++ b/lib/remotus/winrm_connection.rb
@@ -69,14 +69,16 @@ module Remotus
 
     #
     # Retrieves/creates the WinRM shell connection for the host
+    #
+    # @param [symbol] type command type
     # If the connection already exists, the existing connection will be retrieved
     #
-    # @return [WinRM::Shells::Powershell] remote connection
+    # @return [WinRM::Shells::type] remote connection
     #
-    def connection
+    def connection(type = :powershell)
       return @connection unless restart_connection?
 
-      @connection = base_connection(reload: true).shell(:powershell)
+      @connection = base_connection(reload: true).shell(type)
     end
 
     #
@@ -93,13 +95,14 @@ module Remotus
     #
     # @param [String] command command to run
     # @param [Array] args command arguments
-    # @param [Hash] _options unused command options
+    # @param [Hash] options command options
+    # @param [Hash] options type :symbol
     #
     # @return [Remotus::Result] result describing the stdout, stderr, and exit status of the command
     #
-    def run(command, *args, **_options)
+    def run(command, *args, **options)
       command = "#{command}#{args.empty? ? "" : " "}#{args.join(" ")}"
-      run_result = connection.run(command)
+      run_result = connection(options[:type]).run(command)
       Remotus::Result.new(command, run_result.stdout, run_result.stderr, run_result.output, run_result.exitcode)
     rescue WinRM::WinRMAuthorizationError => e
       raise Remotus::AuthenticationError, e.to_s

--- a/remotus.gemspec
+++ b/remotus.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-scp", "~> 3.0"
   spec.add_dependency "net-ssh", "~> 6.1"
   spec.add_dependency "winrm", "~> 2.3"
-  spec.add_dependency "winrm-elevated", "~> 1.2.3"
+  spec.add_dependency "winrm-elevated", "~> 1.2"
   spec.add_dependency "winrm-fs", "~> 1.3"
 
   # Development dependencies

--- a/remotus.gemspec
+++ b/remotus.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-scp", "~> 3.0"
   spec.add_dependency "net-ssh", "~> 6.1"
   spec.add_dependency "winrm", "~> 2.3"
+  spec.add_dependency "winrm-elevated", "~> 1.2.3"
   spec.add_dependency "winrm-fs", "~> 1.3"
 
   # Development dependencies

--- a/spec/remotus/core_ext/elevated_spec.rb
+++ b/spec/remotus/core_ext/elevated_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Remotus::CoreExt::Elevated do
+  let(:connection_opts) do
+    {
+      user: "username",
+      password: "password",
+      domain: "domain_name"
+    }
+  end
+
+  let(:winrm_elevated_connection) do
+    double(WinRM::Connection, shell: double(WinRM::Shells::Elevated), connection_opts: connection_opts)
+  end
+
+  describe "#connection_opts" do
+    it "returns connection_opts object" do
+      expect(winrm_elevated_connection.connection_opts).to eq(connection_opts)
+    end
+  end
+end

--- a/spec/remotus/winrm_connection_spec.rb
+++ b/spec/remotus/winrm_connection_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Remotus::WinrmConnection do
   end
 
   describe "#base_connection" do
-    it "creates the base connection with powershell privilage" do
+    it "creates the base connection with powershell privilege" do
       expect(WinRM::Connection).to receive(:new).with(
         endpoint: "http://#{host}:5985/wsman",
         transport: :negotiate,
@@ -63,7 +63,7 @@ RSpec.describe Remotus::WinrmConnection do
       subject.base_connection
     end
 
-    it "creates the base connection with elevated privilage" do
+    it "creates the base connection with elevated privilege" do
       expect(WinRM::Connection).to receive(:new).with(
         endpoint: "http://#{host}:5985/wsman",
         transport: :negotiate,
@@ -75,7 +75,7 @@ RSpec.describe Remotus::WinrmConnection do
   end
 
   describe "#connection" do
-    it "creates the connection shell with powershell privilage" do
+    it "creates the connection shell with powershell privilege" do
       expect(WinRM::Connection).to receive(:new).with(
         endpoint: "http://#{host}:5985/wsman",
         transport: :negotiate,
@@ -84,8 +84,8 @@ RSpec.describe Remotus::WinrmConnection do
       ).and_return(winrm_connection)
       subject.connection
     end
-    
-    it "creates the connection shell with elevated privilage" do
+
+    it "creates the connection shell with elevated privilege" do
       expect(WinRM::Connection).to receive(:new).with(
         endpoint: "http://#{host}:5985/wsman",
         transport: :negotiate,


### PR DESCRIPTION
PR Changes:-
* Added new gem winrm-elevated
* Provided support to execute WinRM commands with elevated privilege.

**Test Evidence:-**
3.0.0 :001 >  require "bundler/setup"
 => true
3.0.0 :002 > require 'remotus'
 => true
3.0.0 :003 > connection = Remotus.connect("cwhwamgmt05.cwh_wa.cernerasp.com", proto: :winrm)
 => #<Remotus::HostPool:0x00005557c6d5b600 @metadata={}, @host="cwhwamgmt05.cwh_wa.cernerasp.com", @proto=:winrm, @pool=#<ConnectionPool:0x00005557c6d58720 @...
3.0.0 :004 > connection.credential = Remotus::Auth::Credential.new("cernerasp\\svcCWXTIFEAUTO", "*********")
 => Remotus::Auth::Credential: (user: cernerasp\svcCWXTIFEAUTO)
3.0.0 :005 >  result = connection.run("ipconfig",options: {type: :elevated})
is_nil: false and options: {:options=>{:type=>:elevated}}
 => #<Remotus::Result:0x00005557c7ae87a0 @command="ipconfig", @stdout="\r\nWindows IP Configuration\r\n\r\n\r\nEthernet adapter Team:\r\n\r\n   Connection-sp...
3.0.0 :006 >  result = connection.run("ipconfig")
is_nil: false and options: {}
 => #<Remotus::Result:0x00005557c7291f48 @command="ipconfig", @stdout="\r\nWindows IP Configuration\r\n\r\n\r\nEthernet adapter Team:\r\n\r\n   Connection-sp...
3.0.0 :007 > 