### PR TITLE
Fix connection caching and graceful closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.0] - 2022-09-26
+* Add `#close` method to all connection types
+* Fix SSH gateway connection caching
+* Ensure SSH gateway connections are closed gracefully before reinitializing a connection
+
 ## [0.5.0] - 2022-09-21
 * Ensure port argument is respected in `Remotus::SshConnection`
 * Add SSH gateway support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    remotus (0.5.0)
+    remotus (0.6.0)
       connection_pool (~> 2.2)
       net-scp (~> 3.0)
       net-ssh (~> 6.1)

--- a/docker/ssh_integration_spec.rb
+++ b/docker/ssh_integration_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe "Remotus::SshConnection Integration Tests" do
   end
 
   after(:all) do
+    # Close all active connections
+    Remotus.clear
+
     # docker-compose cleanup
     `docker-compose -f "docker-compose.yml" down -v`
   end

--- a/lib/remotus/host_pool.rb
+++ b/lib/remotus/host_pool.rb
@@ -88,6 +88,15 @@ module Remotus
     end
 
     #
+    # Closes all open connections in the pool.
+    # @see Remotus::SshConnection#close
+    # @see Remotus::WinrmConnection#close
+    #
+    def close
+      @pool.reload(&:close)
+    end
+
+    #
     # Provides an SSH or WinRM connection to a given block of code
     #
     # @example Run a command over SSH or WinRM using a pooled connection

--- a/lib/remotus/version.rb
+++ b/lib/remotus/version.rb
@@ -2,5 +2,5 @@
 
 module Remotus
   # Remotus gem version
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/lib/remotus/winrm_connection.rb
+++ b/lib/remotus/winrm_connection.rb
@@ -64,6 +64,9 @@ module Remotus
     def base_connection(reload: false)
       return @base_connection if !reload && !restart_base_connection?
 
+      # Close any active connections
+      close
+
       Remotus.logger.debug { "Initializing WinRM connection to #{Remotus::Auth.credential(self).user}@#{@host}:#{@port}" }
       @base_connection = WinRM::Connection.new(
         endpoint: "http://#{@host}:#{@port}/wsman",
@@ -86,6 +89,15 @@ module Remotus
 
       @shell = shell
       @connection = base_connection(reload: true).shell(@shell)
+    end
+
+    #
+    # Closes the current WinRM connection if it is active
+    #
+    def close
+      @connection&.close
+      @connection = nil
+      @base_connection = nil
     end
 
     #

--- a/spec/remotus/host_pool_spec.rb
+++ b/spec/remotus/host_pool_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe Remotus::HostPool do
     end
   end
 
+  describe "#close" do
+    it "closes the connection on each open connection" do
+      expect(subject.instance_variable_get(:@pool)).to receive(:reload)
+
+      expect { subject.close }.to_not raise_error
+    end
+  end
+
   describe "#expiration_time" do
     it "returns the expiration time" do
       expect(subject.expiration_time).to be_a(Time)

--- a/spec/remotus/pool_spec.rb
+++ b/spec/remotus/pool_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Remotus::Pool do
 
     context "when the pool contains host pools" do
       it "removes all host pools" do
-        described_class.connect(host, proto: :ssh)
+        ssh_connection = described_class.connect(host, proto: :ssh)
+        expect(ssh_connection).to receive(:close)
         expect(described_class.count).to eq(1)
         expect(described_class.clear).to eq(1)
         expect(described_class.count).to eq(0)

--- a/spec/remotus/winrm_connection_spec.rb
+++ b/spec/remotus/winrm_connection_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe Remotus::WinrmConnection do
     end
   end
 
+  describe "#close" do
+    it "closes the associated connection" do
+      subject.connection
+      expect(subject.instance_variable_get(:@connection)).to receive(:close)
+      subject.close
+
+      expect(subject.instance_variable_get(:@connection)).to eq(nil)
+      expect(subject.instance_variable_get(:@base_connection)).to eq(nil)
+    end
+  end
+
   describe "#port_open?" do
     it "calls Remotus.port_open?" do
       expect(Remotus).to receive(:port_open?).with(host, 5985).and_return(true)


### PR DESCRIPTION
* Add `#close` method to all connection types
* Fix SSH gateway connection caching
* Ensure SSH gateway connections are closed gracefully before reinitializing a connection