### PR TITLE
Add support for IP connections with hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.0] - 2023-10-23
+* Add `:ip` option to connection methods to accommodate credential stores that require the hostname where DNS is not available.
+
 ## [1.1.1] - 2023-05-26
 * Handle close failures and improve logging around connection status.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    remotus (1.1.1)
+    remotus (1.2.0)
       connection_pool (~> 2.4)
       net-scp (~> 4.0)
       net-ssh (~> 7.1)
@@ -18,7 +18,7 @@ GEM
     connection_pool (2.4.1)
     diff-lcs (1.5.0)
     erubi (1.12.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
     gyoku (1.4.0)
@@ -33,7 +33,7 @@ GEM
     multi_json (1.15.0)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
-    net-ssh (7.1.0)
+    net-ssh (7.2.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     nori (2.6.0)

--- a/lib/remotus.rb
+++ b/lib/remotus.rb
@@ -18,6 +18,9 @@ module Remotus
   # @option options [Integer] :timeout amount of time to wait for a connection from the pool
   # @option options [Integer] :port port to use for the connection
   # @option options [Symbol]  :proto protocol to use for the connection (:winrm, :ssh), must be specified if port is specified
+  # @option options [String]  :ip IP to use for the connection, preferred over the hostname if set.
+  #                               This should be used if the hostname is required for credential retrieval
+  #                               but the hostname cannot be resolved by DNS.
   #
   # @return [Remotus::HostPool] Newly created or retrieved host pool
   #

--- a/lib/remotus/host_pool.rb
+++ b/lib/remotus/host_pool.rb
@@ -42,12 +42,16 @@ module Remotus
     # @param [Hash] metadata metadata for this connection. Useful for providing additional information to various authentication stores
     #                        should be specified using snake_case symbol keys. If keys are not snake_case, they will be converted.
     #
+    #                        To connect to a host via IP, the following metadata entry can be provided to the host pool:
+    #                          :ip
+    #
     #                        To configure a connection gateway, the following metadata entries can be provided to the host pool:
-    #                          :gateway_host
+    #                          :gateway_host (required to use gateway)
     #                          :gateway_port
     #                          :gateway_metadata
+    #                          :gateway_ip
     #
-    #                        These function similarly to the host, port, and host_pool metadata fields.
+    #                        These function similarly to the host, port, host_pool metadata, and ip fields.
     #
     def initialize(host, size: DEFAULT_POOL_SIZE, timeout: DEFAULT_EXPIRATION_SECONDS, port: nil, proto: nil, **metadata)
       Remotus.logger.debug { "Creating host pool for #{host}" }

--- a/lib/remotus/pool.rb
+++ b/lib/remotus/pool.rb
@@ -20,6 +20,9 @@ module Remotus
       # @option options [Integer] :timeout amount of time to wait for a connection from the pool
       # @option options [Integer] :port port to use for the connection
       # @option options [Symbol]  :proto protocol to use for the connection (:winrm, :ssh), must be specified if port is specified
+      # @option options [String]  :ip IP to use for the connection, preferred over the hostname if set.
+      #                               This should be used if the hostname is required for credential retrieval
+      #                               but the hostname cannot be resolved by DNS.
       #
       # @return [Remotus::HostPool] Host pool for the given host
       #

--- a/lib/remotus/version.rb
+++ b/lib/remotus/version.rb
@@ -2,5 +2,5 @@
 
 module Remotus
   # Remotus gem version
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
* Add `:ip` option to connection methods to accommodate credential stores that require the hostname where DNS is not available.